### PR TITLE
Fix get_embedding to call correct Ollama helper

### DIFF
--- a/split_text_chunks.py
+++ b/split_text_chunks.py
@@ -453,7 +453,7 @@ def get_embedding(text, embedding_type=None, model_name=None):
     else:  # Default to ollama
         if model_name is None:
             model_name = OLLAMA_MODEL_NAME
-        return get_olloma_embedding(text, model_name, OLLAMA_URL)
+        return get_ollama_embedding(text, model_name, OLLAMA_URL)
 
 if __name__ == "__main__":
     print("✨ Welcome to the SUPER FAST Text Processor & Vectorizer! ✨")

--- a/tests/test_split_text_chunks.py
+++ b/tests/test_split_text_chunks.py
@@ -1,0 +1,14 @@
+import split_text_chunks as stc
+
+def test_get_embedding_calls_ollama(monkeypatch):
+    called = {}
+    def fake_get_ollama_embedding(text, model_name, ollama_url):
+        called['called'] = True
+        assert text == 'hello'
+        assert model_name == 'model'
+        assert ollama_url == stc.OLLAMA_URL
+        return [0.1, 0.2]
+    monkeypatch.setattr(stc, 'get_ollama_embedding', fake_get_ollama_embedding)
+    result = stc.get_embedding('hello', embedding_type='ollama', model_name='model')
+    assert called.get('called', False), 'get_ollama_embedding was not called'
+    assert result == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- fix typo in `get_embedding` that called `get_olloma_embedding`
- add regression test verifying the right helper is invoked

## Testing
- `python -m pytest tests/test_split_text_chunks.py -q`
- `python -m pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'output/qa_pairs' in `test_gpu_detailed.py`)*

------
https://chatgpt.com/codex/tasks/task_b_689cd81bd498832faf96e01d474bc97e